### PR TITLE
Add EndOfCheckPhase processor

### DIFF
--- a/gopass/gopass.download.recipe
+++ b/gopass/gopass.download.recipe
@@ -35,6 +35,10 @@
             <string>%NAME%-%version%.tar.gz</string>
          </dict>
       </dict>
+      <dict>
+          <key>Processor</key>
+          <string>EndOfCheckPhase</string>
+      </dict>
    </array>
 </dict>
 </plist>


### PR DESCRIPTION
The EndOfCheckPhase processor allows administrators to use `autopkg run --check`, which is typically used to check for newly available software versions but not process any subsequent steps. It's typical to include the EndOfCheckPhase processor in most .download recipes.