### PR TITLE
Update ChemDoodle Download Recipe

### DIFF
--- a/ChemDoodle/ChemDoodle.download.recipe
+++ b/ChemDoodle/ChemDoodle.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://www.chemdoodle.com/download/</string>
                 <key>re_pattern</key>
-                <string>ChemDoodle-osx-(?P&lt;raw_version&gt;[0-9\.\-]+)\.dmg</string>
+                <string>ChemDoodle-macos-(?P&lt;raw_version&gt;[0-9\.\-]+)\.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.chemdoodle.com/downloads/ChemDoodle-osx-%raw_version%.dmg</string>
+                <string>https://www.chemdoodle.com/downloads/ChemDoodle-macos-%raw_version%.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
DMG file name format changed from ChemDoodle-osx-[VERSION].dmg to ChemDoodle-macos-[VERSION].dmg.