### PR TITLE
Fixes for PostgreSQL recipes

### DIFF
--- a/postgresql/PostgreSQL.download.recipe
+++ b/postgresql/PostgreSQL.download.recipe
@@ -25,7 +25,7 @@
                 <key>url</key>
                 <string>https://www.enterprisedb.com/download-postgresql-binaries</string>
                 <key>re_pattern</key>
-                <string>postgresql-(?P&lt;raw_version&gt;[0-9\.\-]+)-osx-binaries\.zip</string>
+                <string>&lt;b&gt;Version (\S*)&lt;\/b&gt;</string>
             </dict>
         </dict>
         <dict>
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://get.enterprisedb.com/postgresql/postgresql-%raw_version%-osx.dmg</string>
+                <string>https://get.enterprisedb.com/postgresql/postgresql-%match%-1-osx.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/postgresql-%raw_version%-osx.app</string>
+                <string>%pathname%/postgresql-%match%-1-osx.app</string>
                 <key>requirement</key>
                 <string>identifier "com.edb.postgresql" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "26QKX55P9K"</string>
             </dict>

--- a/postgresql/PostgreSQL.munki.recipe
+++ b/postgresql/PostgreSQL.munki.recipe
@@ -3,62 +3,94 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of PostgreSQL and imports it into Munki.</string>
+    <string>Repackages PostgreSQL into a standard format that can be used in automated installations</string>
     <key>Identifier</key>
-    <string>com.github.wholtz.munki.PostgreSQL</string>
+    <string>com.github.wholtz.pkg.PostgreSQL</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>PostgreSQL</string>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps/%NAME%</string>
-        <key>pkginfo</key>
-        <dict>
-            <key>catalogs</key>
-            <array>
-                <string>testing</string>
-            </array>
-            <key>description</key>
-            <string>PostgreSQL database system packaged by EnterpriseDB.com.
-
-This installer includes the PostgreSQL server, pgAdmin; a graphical tool for managing and developing your databases, and StackBuilder; a package manager that can be used to download and install additional PostgreSQL tools and drivers. Stackbuilder includes management, integration, migration, replication, geospatial, connectors and other tools. </string>
-            <key>developer</key>
-            <string>EnterpriseDB Corporation</string>
-            <key>display_name</key>
-            <string>PostgreSQL</string>
-            <key>name</key>
-            <string>%NAME%</string>
-            <key>unattended_install</key>
-            <true/>
-            <key>uninstall_script</key>
-            <string>#!/bin/bash
-
-VERSIONS=$(ls -1 /Library/PostgreSQL)
-for V in ${VERSIONS}
-do
-   /Library/PostgreSQL/${V}/uninstall-postgresql.app/Contents/MacOS/installbuilder.sh --unattendedmodeui none --mode unattended
-done
-
-</string>
-        </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.wholtz.pkg.PostgreSQL</string>
+    <string>com.github.wholtz.download.PostgreSQL</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>MunkiImporter</string>
+            <string>PkgRootCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkg_path</key>
-                <string>%pkg_path%</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>version_comparison_key</key>
-                <string>CFBundleVersion</string>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                <key>pkgdirs</key>
+                <dict/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Copier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_path</key>
+                <string>%pathname%/postgresql-%match%-1-osx.app</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Scripts/postgresql-%match%-1-osx.app</string>
+                <key>overwrite</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>file_path</key>
+                <string>%RECIPE_CACHE_DIR%/Scripts/postinstall</string>
+                <key>file_mode</key>
+                <string>0755</string>
+                <key>file_content</key>
+                <string>#!/bin/bash
+
+# Determine working directory
+install_dir=$(dirname $0)
+
+# install with no UI
+"${install_dir}/postgresql-%match%-1-osx.app/Contents/MacOS/osx-x86_64" --unattendedmodeui none --mode unattended</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_request</key>
+                <dict>
+                    <key>pkgroot</key>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%match%</string>
+                    <key>pkgtype</key>
+                    <string>flat</string>
+                    <key>id</key>
+                    <string>com.enterprisedb.postgresql.pkg</string>
+                    <key>version</key>
+                    <string>%match%</string>
+                    <key>scripts</key>
+                    <string>Scripts</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Scripts</string>
+                </array>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
These changes enable the download recipe to grab the latest version and the pkg recipe to call the 64 bit installer to work on current macOS systems.