### PR TITLE
Package Recipe Processor Unarchiver not working with FileMover

### DIFF
--- a/gopass/gopass.pkg.recipe
+++ b/gopass/gopass.pkg.recipe
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source</key>
-                <string>%destination_path%/%NAME%-%version%-darwin-amd64/gopass</string>
+                <string>%destination_path%/%NAME%</string>
                 <key>target</key>
                 <string>%pkgroot%/usr/local/bin/gopass</string>
             </dict>


### PR DESCRIPTION
Unarchiver unarchives gopass to this path:

~/Library/AutoPkg/Cache/local.munki.gopass/gopass/gopass

Whereas FileMover processor believes there is a gopass file in this form:

~/Library/AutoPkg/Cache/local.munki.gopass/gopass/gopass-[VERSION]-darwin-amd64

So FileMover throws an error like:

Error in local.munki.gopass: Processor: FileMover: Error: [Errno 2] No such file or directory: '~/Library/AutoPkg/Cache/local.munki.gopass/gopass/gopass-1.14.6-darwin-amd64/gopass' -> '~/Library/AutoPkg/Cache/local.munki.gopass/gopass_pkg/usr/local/bin/gopass'

Probably this is b/c the binary is now compiled 'Universal'...
