### PR TITLE
Adjust download page and pattern for PostgreSQL

### DIFF
--- a/postgresql/PostgreSQL.download.recipe
+++ b/postgresql/PostgreSQL.download.recipe
@@ -23,9 +23,10 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.enterprisedb.com/download-postgresql-binaries</string>
+                <string>https://www.enterprisedb.com/downloads/postgres-postgresql-downloads</string>
                 <key>re_pattern</key>
-                <string>&lt;b&gt;Version (\S*)&lt;\/b&gt;</string>
+                <!-- <string>&lt;b&gt;Version (\S*)&lt;\/b&gt;</string> -->
+                <string>table-body"&gt;([\d\.]+)&lt;/td&gt;</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR updates the download page and file pattern used to download PostgreSQL installers.

Verbose recipe run output:

```
% autopkg run -vvq 'postgresql/PostgreSQL.download.recipe'
Processing postgresql/PostgreSQL.download.recipe...
WARNING: postgresql/PostgreSQL.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'table-body">([\\d\\.]+)</td>',
           'url': 'https://www.enterprisedb.com/downloads/postgres-postgresql-downloads'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): 17.2
{'Output': {'match': '17.2'}}
URLDownloader
{'Input': {'url': 'https://get.enterprisedb.com/postgresql/postgresql-17.2-1-osx.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 21 Nov 2024 10:42:59 GMT
URLDownloader: Storing new ETag header: "79f1857605760e706164fc69a911f264-25"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.wholtz.download.PostgreSQL/downloads/postgresql-17.2-1-osx.dmg
{'Output': {'download_changed': True,
            'etag': '"79f1857605760e706164fc69a911f264-25"',
            'last_modified': 'Thu, 21 Nov 2024 10:42:59 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.wholtz.download.PostgreSQL/downloads/postgresql-17.2-1-osx.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.wholtz.download.PostgreSQL/downloads/postgresql-17.2-1-osx.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.wholtz.download.PostgreSQL/downloads/postgresql-17.2-1-osx.dmg/postgresql-17.2-1-osx.app',
           'requirement': 'identifier "com.edb.postgresql" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"26QKX55P9K"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.wholtz.download.PostgreSQL/downloads/postgresql-17.2-1-osx.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.DIqQoc/postgresql-17.2-1-osx.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.DIqQoc/postgresql-17.2-1-osx.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.DIqQoc/postgresql-17.2-1-osx.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.wholtz.download.PostgreSQL/receipts/PostgreSQL.download-receipt-20241228-071853.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.wholtz.download.PostgreSQL/downloads/postgresql-17.2-1-osx.dmg
```

