### PR TITLE
Fix ChemDoodle download recipe and add multiple architecture support

### DIFF
--- a/ChemDoodle/ChemDoodle.download.recipe
+++ b/ChemDoodle/ChemDoodle.download.recipe
@@ -3,13 +3,20 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of ChemDoodle.</string>
+    <string>Downloads the latest version of ChemDoodle.
+    
+Valid values for ARCH include:
+- "x64" (default, Intel)
+- "aarch64" (Apple Silicon)
+</string>
     <key>Identifier</key>
     <string>com.github.wholtz.chemdoodle.download</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>ChemDoodle</string>
+        <key>ARCH</key>
+        <string>x64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -23,7 +30,7 @@
                 <key>url</key>
                 <string>https://www.chemdoodle.com/download/</string>
                 <key>re_pattern</key>
-                <string>ChemDoodle-macos-(?P&lt;raw_version&gt;[0-9\.\-]+)\.dmg</string>
+                <string>ChemDoodle-macos-%ARCH%-(?P&lt;raw_version&gt;[0-9\.\-]+)\.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -32,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.chemdoodle.com/downloads/ChemDoodle-macos-%raw_version%.dmg</string>
+                <string>https://www.chemdoodle.com/downloads/ChemDoodle-macos-%ARCH%-%raw_version%.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR adds an ARCH input variable that can be used to specify whether to download the Intel or Apple Silicon version of ChemDoodle.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'ChemDoodle/ChemDoodle.download.recipe'
Processing ChemDoodle/ChemDoodle.download.recipe...
WARNING: ChemDoodle/ChemDoodle.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'ChemDoodle-macos-x64-(?P<raw_version>[0-9\\.\\-]+)\\.dmg',
           'url': 'https://www.chemdoodle.com/download/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (raw_version): 12.7.0
URLTextSearcher: Found matching text (match): 12.7.0
{'Output': {'match': '12.7.0', 'raw_version': '12.7.0'}}
URLDownloader
{'Input': {'url': 'https://www.chemdoodle.com/downloads/ChemDoodle-macos-x64-12.7.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 21 Oct 2024 15:06:11 GMT
URLDownloader: Storing new ETag header: "68ae136-624fdfe3cfec0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-x64-12.7.0.dmg
{'Output': {'download_changed': True,
            'etag': '"68ae136-624fdfe3cfec0"',
            'last_modified': 'Mon, 21 Oct 2024 15:06:11 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-x64-12.7.0.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-x64-12.7.0.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-x64-12.7.0.dmg/ChemDoodle/ChemDoodle.app',
           'requirement': 'identifier "com.iChemLabs.ChemDoodle" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"9XP397UW95"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-x64-12.7.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.yZTTqX/ChemDoodle/ChemDoodle.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.yZTTqX/ChemDoodle/ChemDoodle.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.yZTTqX/ChemDoodle/ChemDoodle.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/receipts/ChemDoodle.download-receipt-20241228-070402.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-x64-12.7.0.dmg
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq "ChemDoodle/ChemDoodle.download.recipe" -k ARCH=aarch64
Processing ChemDoodle/ChemDoodle.download.recipe...
WARNING: ChemDoodle/ChemDoodle.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'ChemDoodle-macos-aarch64-(?P<raw_version>[0-9\\.\\-]+)\\.dmg',
           'url': 'https://www.chemdoodle.com/download/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (raw_version): 12.7.0
URLTextSearcher: Found matching text (match): 12.7.0
{'Output': {'match': '12.7.0', 'raw_version': '12.7.0'}}
URLDownloader
{'Input': {'url': 'https://www.chemdoodle.com/downloads/ChemDoodle-macos-aarch64-12.7.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 21 Oct 2024 15:06:10 GMT
URLDownloader: Storing new ETag header: "67870a2-624fdfe2dbc80"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-aarch64-12.7.0.dmg
{'Output': {'download_changed': True,
            'etag': '"67870a2-624fdfe2dbc80"',
            'last_modified': 'Mon, 21 Oct 2024 15:06:10 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-aarch64-12.7.0.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-aarch64-12.7.0.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-aarch64-12.7.0.dmg/ChemDoodle/ChemDoodle.app',
           'requirement': 'identifier "com.iChemLabs.ChemDoodle" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"9XP397UW95"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-aarch64-12.7.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.1FqICr/ChemDoodle/ChemDoodle.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.1FqICr/ChemDoodle/ChemDoodle.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.1FqICr/ChemDoodle/ChemDoodle.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/receipts/ChemDoodle.download-receipt-20241228-070556.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.wholtz.chemdoodle.download/downloads/ChemDoodle-macos-aarch64-12.7.0.dmg
```

