### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/gopass/gopass.pkg.recipe
+++ b/gopass/gopass.pkg.recipe
@@ -87,8 +87,6 @@
                     <string>%RECIPE_CACHE_DIR%/</string>
                     <key>id</key>
                     <string>com.github.justwatchcom.gopass</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>version</key>
                     <string>%version%</string>
                     <key>chown</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._